### PR TITLE
disabling `throwHttpErrors` and adding a note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Place the following content inside:
 
 Repeat for `BLUE`.
 
+> Note: when repeating for `BLUE` make sure to update the paths inside `post-receive` hook.
+
 ### Setting git remotes
 
 On your host computer, clone the [meow.io repo](https://github.com/CSC-DevOps/meow.io), and set the following remotes, using the ssh protocol:
@@ -118,7 +120,7 @@ Repeat the same for the `GREEN` environment.
 
 ## Settting up Infrastructure
 
-Currently, we can deploy changes to our different VMs---however---we have nothing the regulates the control of traffic, nor logic which determines which `TARGET` is active. We will set up our infrastructure to fully handle a deployment, including automatic failover.
+Currently, we can deploy changes to our different VMs---however---we have nothing that regulates the control of traffic, nor logic which determines which `TARGET` is active. We will set up our infrastructure to fully handle a deployment, including automatic failover.
 
 You may want to setup your terminals to help you distinguish your `GREEN` and `BLUE` environments, as follows:
 

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -55,7 +55,7 @@ class Production
    {
       try 
       {
-         const response = await got(this.TARGET);
+         const response = await got(this.TARGET, {throwHttpErrors: false});
          let status = response.statusCode == 200 ? chalk.green(response.statusCode) : chalk.red(response.statusCode);
          console.log( chalk`{grey Health check on ${this.TARGET}}: ${status}`);
       }


### PR DESCRIPTION
- disabling [`throwHttpErrors`](https://www.npmjs.com/package/got#throwhttperrors) to allow checking status when it's != 200.
- adding a note in readme to remind paths inside `post-receive` hook need to be updated when repeating for `BLUE`.